### PR TITLE
docs: add initial README and TODO documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,148 @@
-# @ai-primitives/package-template
+# hono-mdx
 
-[![npm version](https://badge.fury.io/js/%40ai-primitives%2Fpackage-template.svg)](https://www.npmjs.com/package/@ai-primitives/package-template)
+[![npm version](https://badge.fury.io/js/hono-mdx.svg)](https://badge.fury.io/js/hono-mdx)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A modern TypeScript package template with Vitest, Prettier, ESLint, and semantic versioning.
+Seamless MDX integration for Hono applications, providing first-class JSX support via @mdx-js/react. Build content-rich applications with the power of MDX and the performance of Cloudflare Workers.
 
 ## Features
 
-- 🚀 TypeScript for type safety and modern JavaScript features
-- ⚡️ Vitest for fast, modern testing
-- 🎨 Prettier for consistent code formatting
-- 🔍 ESLint for code quality
-- 📦 Semantic versioning with automated releases
-- 🔄 GitHub Actions for CI/CD
+- 🚀 Native Hono JSX rendering for MDX content
+- 📝 Built-in Layout component with PicoCSS and optional Tailwind CSS
+- 🎨 Automatic meta tag generation from MDX frontmatter
+- 🌐 Optimized for Cloudflare Workers
+- ⚡ Streaming SSR support
+- 🔄 Hot module replacement during development
 
-## Installation
+## Quick Start
 
 ```bash
-pnpm add @ai-primitives/package-template
+npm install hono-mdx
+# or
+pnpm add hono-mdx
 ```
 
-## Usage
+### TypeScript Configuration
+
+Add the following to your `tsconfig.json`:
+
+```json
+{
+  'compilerOptions': {
+    'jsx': 'react-jsx',
+    'jsxImportSource': 'hono/jsx',
+    'target': 'esnext',
+    'module': 'esnext',
+    'types': ['@cloudflare/workers-types']
+  }
+}
+```
+
+### Basic Usage
 
 ```typescript
-import { add } from '@ai-primitives/package-template'
+import { Hono } from 'hono'
+import { mdx } from 'hono-mdx'
+import content from './content/index.mdx'
 
-const result = add(1, 2) // returns 3
+const app = new Hono()
+app.use('/', mdx(content))
+
+export default app
 ```
 
-## Development
+### MDX Content with Frontmatter
 
-```bash
-# Install dependencies
-pnpm install
+```mdx
+---
+title: My Page
+description: A great page built with Hono MDX
+keywords: ['hono', 'mdx', 'cloudflare']
+ogTitle: My Amazing Page
+ogDescription: Check out this awesome page
+ogImage: https://example.com/image.jpg
+jsonLd: {
+  '$type': 'WebPage',
+  'name': 'My Page',
+  'description': 'A great page built with Hono MDX'
+}
+---
 
-# Run tests
-pnpm test
+# Welcome to My Page
 
-# Run tests in watch mode
-pnpm test:watch
-
-# Build the package
-pnpm build
-
-# Lint the code
-pnpm lint
-
-# Format the code
-pnpm format
+This is a page built with Hono MDX.
 ```
 
-## Contributing
+## Layout Component
 
-Please read our [Contributing Guide](./CONTRIBUTING.md) to learn about our development process and how to propose bugfixes and improvements.
+The built-in Layout component provides:
 
-## License
+- PicoCSS for minimal, semantic HTML styling
+- Optional Tailwind CSS via CDN for customization
+- Automatic meta tag generation from frontmatter
+- SEO-friendly defaults
+- JSON-LD support
 
-MIT © [AI Primitives](https://mdx.org.ai)
+```typescript
+import { mdx } from 'hono-mdx'
+import content from './content.mdx'
+
+// Default layout with PicoCSS
+app.use('/', mdx(content))
+
+// Enable Tailwind CSS
+app.use('/', mdx(content, { useTailwind: true }))
+
+// Custom layout
+app.use('/', mdx(content, {
+  layout: ({ children, frontmatter }) => (
+    <CustomLayout meta={frontmatter}>
+      {children}
+    </CustomLayout>
+  )
+}))
+```
+
+## Meta Tags
+
+The Layout component automatically generates:
+
+- Basic meta tags (title, description, keywords)
+- Open Graph tags (title, description, image, url)
+- JSON-LD structured data
+- Twitter card tags
+
+All meta information is extracted from the MDX frontmatter.
+
+## API Reference
+
+### MDX Middleware Options
+
+```typescript
+interface MDXOptions {
+  useTailwind?: boolean // Enable Tailwind CSS
+  layout?: (props: LayoutProps) => JSX.Element // Custom layout component
+  wrapper?: (props: WrapperProps) => JSX.Element // Custom MDX wrapper
+}
+
+interface LayoutProps {
+  children: JSX.Element
+  frontmatter: MDXFrontmatter
+}
+
+interface MDXFrontmatter {
+  title?: string
+  description?: string
+  keywords?: string[]
+  ogTitle?: string
+  ogDescription?: string
+  ogImage?: string
+  ogUrl?: string
+  jsonLd?: Record<string, unknown>
+}
+```
 
 ## Dependencies
 
-This package uses the following key dependencies:
-
-- TypeScript for static typing
-- Vitest for testing
-- ESLint for linting
-- Prettier for code formatting
+- [hono](https://www.npmjs.com/package/hono) - Fast, lightweight web framework
+- [@mdx-js/react](https://www.npmjs.com/package/@mdx-js/react) - React implementation for MDX

--- a/TODO.md
+++ b/TODO.md
@@ -1,44 +1,102 @@
-# Project Status and Tasks
+# hono-mdx Implementation Plan
 
-## Setup and Configuration
+## Core Package Implementation
 
-- [x] Initialize package with TypeScript configuration
-- [x] Set up Vitest for testing
-- [x] Configure ESLint and Prettier
-- [x] Set up basic project structure
-- [x] Create placeholder implementation and tests
-- [x] Configure package.json with proper metadata
+- [ ] Initial Setup
+  - [ ] Configure TypeScript with Hono JSX support
+  - [ ] Set up ESLint and Prettier
+  - [ ] Configure build system with esbuild
+  - [ ] Set up MDX plugin configuration
 
-## Implementation
-- [x] Basic package structure
-  - [x] TypeScript configuration
-  - [x] Testing setup with Vitest
-  - [x] ESLint and Prettier configuration
-- [x] CLI functionality
-  - [x] Basic command-line interface
-  - [x] Version and help commands
-- [ ] Advanced features
-  - [ ] Additional CLI commands
-  - [ ] Extended test coverage
-  - [ ] Documentation examples
+- [ ] MDX Integration
+  - [ ] Create MDX types and interfaces
+    - [ ] Define MDXFrontmatter interface
+    - [ ] Create MDXOptions type
+    - [ ] Implement LayoutProps interface
+  - [ ] Implement MDX middleware
+    - [ ] Add frontmatter parsing
+    - [ ] Set up @mdx-js/react integration
+    - [ ] Configure JSX rendering
+  - [ ] Add streaming SSR support
+    - [ ] Implement chunked transfer encoding
+    - [ ] Add suspense boundary handling
+
+- [ ] Layout Component
+  - [ ] Create base Layout component
+    - [ ] Add PicoCSS integration
+    - [ ] Implement Tailwind CSS support
+  - [ ] Meta Tag Management
+    - [ ] Implement basic meta tags
+    - [ ] Add Open Graph support
+    - [ ] Add Twitter card support
+    - [ ] Implement JSON-LD integration
+  - [ ] Component Customization
+    - [ ] Add custom layout support
+    - [ ] Implement MDX component mapping
+    - [ ] Create wrapper component API
+
+## Examples
+
+- [ ] Coming Soon Example
+  - [ ] Basic page structure
+  - [ ] Meta tag implementation
+  - [ ] Cloudflare Workers setup
+  - [ ] Build configuration
+  - [ ] Deployment instructions
+
+- [ ] Blog Example
+  - [ ] Multiple page setup
+    - [ ] Home page
+    - [ ] Blog post listing
+    - [ ] Individual post pages
+  - [ ] Navigation implementation
+  - [ ] Meta tag customization
+  - [ ] Build and deployment setup
 
 ## Documentation
 
-- [x] Create README with badges and usage instructions
-- [ ] Complete CONTRIBUTING.md guide
-- [ ] Add API documentation
-- [ ] Add examples directory with usage examples
+- [x] README
+  - [x] Installation instructions
+  - [x] Configuration guide
+  - [x] Usage examples
+  - [x] API reference
+  - [x] Meta tag documentation
 
-## CI/CD
+- [ ] API Documentation
+  - [ ] TypeScript interfaces
+  - [ ] Component props
+  - [ ] Middleware options
+  - [ ] Configuration options
 
-- [ ] Set up GitHub Actions workflow
-- [ ] Configure semantic-release
-- [ ] Add test coverage reporting
-- [ ] Set up automated npm publishing
+- [ ] Contributing Guidelines
+  - [ ] Development setup
+  - [ ] Testing instructions
+  - [ ] Pull request process
+  - [ ] Code style guide
+
+## Testing and CI/CD
+
+- [ ] Testing Setup
+  - [ ] Unit tests
+  - [ ] Integration tests
+  - [ ] Example deployment tests
+
+- [ ] CI/CD Pipeline
+  - [ ] GitHub Actions setup
+  - [ ] Automated testing
+  - [ ] Release automation
+  - [ ] Version management
 
 ## Future Enhancements
 
-- [ ] Add more comprehensive examples
-- [ ] Add changelog generation
-- [ ] Add pull request template
-- [ ] Add issue templates
+- [ ] Advanced Features
+  - [ ] Code syntax highlighting
+  - [ ] Image optimization
+  - [ ] Cache control
+  - [ ] Custom MDX plugins
+
+- [ ] Performance Optimization
+  - [ ] Bundle size optimization
+  - [ ] Streaming improvements
+  - [ ] Resource caching
+  - [ ] Edge caching strategies


### PR DESCRIPTION
Initial README and TODO documentation for hono-mdx package

This PR adds:
- Comprehensive README documenting:
  - Hono JSX support for MDX via @mdx-js/react
  - Required compiler options for TypeScript/JSX
  - Layout component with PicoCSS and Tailwind CDN integration
  - HTML meta tag and JSON-LD support from MDX frontmatter
- Detailed TODO.md with implementation plan using nested task lists

The documentation establishes the design and requirements before implementation begins.

Link to Devin run: https://app.devin.ai/sessions/4ac3c87cdc9c4d569a609d74a510fd95
